### PR TITLE
Save the map tiles directly to the base directory

### DIFF
--- a/src/AbstractMapProvider.cpp
+++ b/src/AbstractMapProvider.cpp
@@ -66,10 +66,6 @@ void AbstractMapProvider::Initialize(const MapSettings &settings)
 
     AnsiString homeDir = ExtractFilePath(ExtractFileDir(Application->ExeName));
     homeDir += settings.baseDirectory.c_str();
-    if (settings.loadFromInternet)
-        homeDir += settings.liveDirectory.c_str();
-    else
-        homeDir += "\\";
     std::string cachedir = homeDir.c_str();
 
     if (mkdir(cachedir.c_str()) != 0 && errno != EEXIST)

--- a/src/AbstractMapProvider.h
+++ b/src/AbstractMapProvider.h
@@ -20,7 +20,6 @@ protected:
   struct MapSettings
   {
     std::string baseDirectory;
-    std::string liveDirectory;
     int mapType;
     bool loadFromInternet;
   };

--- a/src/GoogleMapProvider.cpp
+++ b/src/GoogleMapProvider.cpp
@@ -4,7 +4,6 @@ void GoogleMapProvider::Initialize(bool loadFromInternet)
 {
     MapSettings settings;
     settings.baseDirectory = "..\\GoogleMap\\";
-    settings.liveDirectory = "_Live\\";
     settings.mapType = GoogleMaps;
     settings.loadFromInternet = loadFromInternet;
 

--- a/src/IFRHighMapProvider.cpp
+++ b/src/IFRHighMapProvider.cpp
@@ -4,7 +4,6 @@ void IFRHighMapProvider::Initialize(bool loadFromInternet)
 {
     MapSettings settings;
     settings.baseDirectory = "..\\IFR_High_Map\\";
-    settings.liveDirectory = "_Live\\";
     settings.mapType = SkyVector_IFR_High;
     settings.loadFromInternet = loadFromInternet;
 

--- a/src/IFRLowMapProvider.cpp
+++ b/src/IFRLowMapProvider.cpp
@@ -4,7 +4,6 @@ void IFRLowMapProvider::Initialize(bool loadFromInternet)
 {
     MapSettings settings;
     settings.baseDirectory = "..\\IFR_Low_Map\\";
-    settings.liveDirectory = "_Live\\";
     settings.mapType = SkyVector_IFR_Low;
     settings.loadFromInternet = loadFromInternet;
 

--- a/src/VFRMapProvider.cpp
+++ b/src/VFRMapProvider.cpp
@@ -4,7 +4,6 @@ void VFRMapProvider::Initialize(bool loadFromInternet)
 {
     MapSettings settings;
     settings.baseDirectory = "..\\VFR_Map\\";
-    settings.liveDirectory = "_Live\\";
     settings.mapType = SkyVector_VFR;
     settings.loadFromInternet = loadFromInternet;
 


### PR DESCRIPTION
That way, tile syncing between the base and live directories isn’t necessary.