### PR TITLE
Feature/qa 14/track age

### DIFF
--- a/src/Aircraft.h
+++ b/src/Aircraft.h
@@ -11,6 +11,7 @@ typedef struct
     uint32_t ICAO;
     char HexAddr[7];     /* Printable ICAO address */
     __int64 LastSeen;    /* Time at which the last packet was received. */
+    char TimeElapsedInSec[3]; /* Time elapsed in seconds since the last packet was received. */
     long NumMessagesRaw; /* Number of Mode S messages received. */
     long NumMessagesSBS;
     int odd_cprlat; /* Encoded latitude and longitude as extracted by odd and even */

--- a/src/Components/OpenGLv0.5BDS2006/Component/OpenGLPanel.cpp
+++ b/src/Components/OpenGLv0.5BDS2006/Component/OpenGLPanel.cpp
@@ -71,14 +71,17 @@ __fastcall TOpenGLPanel::TOpenGLPanel(TComponent* Owner)
  Font3DDefault=NULL;
 
  Font2DEnabled=false;
- Font2DType= new TFont;
+ Font2DType= new TFont; // no delete -> memory leak?
  Font2DType->Name="Arial";
  Font2DType->Style<< fsBold;
  Font2DType->Height=-9;
  Font2DType->Charset=ANSI_CHARSET;
- Font2DFirstGylph=32;
- Font2DNumGylph=96;
+ Font2DFirstGylph=32; // first character (ASCII) to include
+ Font2DNumGylph=96;   // # characters to include from the first character
  Font2DDefault=NULL;
+
+ Font2DAdditionalType= new TFont; // no delete -> memory leak?
+ Font2DAdditional=NULL;
 }
 //---------------------------------------------------------------------------
 namespace Openglpanel
@@ -189,6 +192,7 @@ namespace Openglpanel
  {
   delete Font3DDefault;
   delete Font2DDefault;
+  delete Font2DAdditional;
   wglMakeCurrent(NULL,NULL);
   if (GLRenderingContext!=NULL)
         {
@@ -249,11 +253,12 @@ void __fastcall TOpenGLPanel::Create3DFont(void)
   }
 //---------------------------------------------------------------------------
 //---------------------------------------------------------------------------
-void __fastcall TOpenGLPanel::Create2DFont(void)
-  {
-   delete Font2DDefault;
-   Font2DDefault=Create2DFont(Font2DType,Font2DFirstGylph,Font2DNumGylph);
-  }
+void __fastcall TOpenGLPanel::Create2DFont(void) {
+  delete Font2DDefault;
+  Font2DDefault = Create2DFont(Font2DType, Font2DFirstGylph, Font2DNumGylph);
+  delete Font2DAdditional;
+  Font2DAdditional = Create2DFont(Font2DAdditionalType, Font2DFirstGylph, Font2DNumGylph);
+}
 //---------------------------------------------------------------------------
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // Private Methods (Property)
@@ -326,11 +331,17 @@ void __fastcall TOpenGLPanel::SetFont3DFormat(const TFont3DFormat Value)
    return;
   }
 //---------------------------------------------------------------------------
-void __fastcall TOpenGLPanel::SetFont(TFont* Value)
-  {
-   Font2DType->Assign(Value);
-   return;
-  }
+void __fastcall TOpenGLPanel::SetFont2DDefaultType(TFont* Value)
+{
+  Font2DType->Assign(Value);
+  return;
+}
+//---------------------------------------------------------------------------
+void __fastcall TOpenGLPanel::SetFont2DAdditionalType(TFont* Value)
+{
+  Font2DAdditionalType->Assign(Value);
+  return;
+}
 //---------------------------------------------------------------------------
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // Protected Methods
@@ -747,10 +758,15 @@ OpenGLFont2D * __fastcall TOpenGLPanel::Create2DFont(TFont *Font,
  return(Font2D);
  }
 //---------------------------------------------------------------------------
-void __fastcall TOpenGLPanel::Draw2DText(AnsiString Text)
+void __fastcall TOpenGLPanel::Draw2DTextDefault(AnsiString Text)
  {
   Draw2DText(Font2DDefault,Text);
  }
+ //---------------------------------------------------------------------------
+void __fastcall TOpenGLPanel::Draw2DTextAdditional(AnsiString Text)
+{
+  Draw2DText(Font2DAdditional,Text);
+}
 //---------------------------------------------------------------------------
 void __fastcall TOpenGLPanel::Draw2DText(OpenGLFont2D *Font,AnsiString Text)
 {

--- a/src/Components/OpenGLv0.5BDS2006/Component/OpenGLPanel.h
+++ b/src/Components/OpenGLv0.5BDS2006/Component/OpenGLPanel.h
@@ -64,6 +64,9 @@ private:
    int                   Font2DNumGylph;
    OpenGLFont2D        * Font2DDefault;
 
+   TFont               * Font2DAdditionalType;
+   OpenGLFont2D        * Font2DAdditional;
+
    // Methods
               bool   __fastcall CreateGLContext(void);
               void   __fastcall DestroyGLContext(void);
@@ -82,7 +85,8 @@ private:
 
               void   __fastcall SetFont3DType(TFont* Value);
               void   __fastcall SetFont3DFormat(const TFont3DFormat Value);
-              void   __fastcall SetFont(TFont* Value);
+              void   __fastcall SetFont2DDefaultType(TFont* Value);
+              void   __fastcall SetFont2DAdditionalType(TFont* Value);
 
 protected:
    // Variables
@@ -115,7 +119,8 @@ public:
               OpenGLFont2D *
                      __fastcall Create2DFont(TFont *Font, int FirstGylph,
                                              int NumGylph);
-              void   __fastcall Draw2DText(AnsiString Text);
+              void   __fastcall Draw2DTextDefault(AnsiString Text);
+              void   __fastcall Draw2DTextAdditional(AnsiString Text);
               void   __fastcall Draw2DText(OpenGLFont2D * Font,AnsiString Text);
 
               BMPTexture *
@@ -191,7 +196,10 @@ __published:
                                  write=Font2DEnabled, default=false};
 
    __property TFont              * Font2D_Type = {read=Font2DType,
-                                 write=SetFont};
+                                 write=SetFont2DDefaultType};
+
+   __property TFont              * Font2D_AdditionalType = {read=Font2DAdditionalType,
+                                 write=SetFont2DAdditionalType};
 
    __property int                Font2D_FirstGylph = {read=Font2DFirstGylph,
                                  write=Font2DFirstGylph, default=32};

--- a/src/DisplayGUI.cpp
+++ b/src/DisplayGUI.cpp
@@ -446,10 +446,9 @@ void __fastcall TForm1::DrawObjects(void)
 
             LatLon2XY(Data->Latitude, Data->Longitude, ScrX, ScrY);
             // DrawPoint(ScrX,ScrY);
-            if (Data->HaveSpeedAndHeading)
+            if (Data->HaveSpeedAndHeading) {
                 glColor4f(1.0, 0.0, 1.0, 1.0);  // with speed & heading - magenta color
-            else
-            {
+            } else {
                 Data->Heading = 0.0;
                 glColor4f(1.0, 0.0, 0.0, 1.0);  // no speed & heading - red
             }
@@ -458,7 +457,7 @@ void __fastcall TForm1::DrawObjects(void)
 
             // ICAO code text besides the aircraft
             glRasterPos2i(ScrX + 60, ScrY - 10);
-            ObjectDisplay->Draw2DText(Data->HexAddr);
+            ObjectDisplay->Draw2DTextDefault(Data->HexAddr);
 
             // heading line
             if ((Data->HaveSpeedAndHeading) && (TimeToGoCheckBox->State == cbChecked))

--- a/src/DisplayGUI.cpp
+++ b/src/DisplayGUI.cpp
@@ -459,6 +459,12 @@ void __fastcall TForm1::DrawObjects(void)
             glRasterPos2i(ScrX + 60, ScrY - 10);
             ObjectDisplay->Draw2DTextDefault(Data->HexAddr);
 
+            // track age information below the ICAO code
+            glColor4f(1.0, 0.0, 0.0, 1.0);  // red
+            glRasterPos2i(ScrX + 60, ScrY - 25);    // TODO: location should be adjusted based on font size setting from the dfm file
+            TimeDifferenceInSecToChar(Data->LastSeen, Data->TimeElapsedInSec, sizeof(Data->TimeElapsedInSec));
+            ObjectDisplay->Draw2DTextAdditional(Data->TimeElapsedInSec + AnsiString(" seconds ago"));
+
             // heading line
             if ((Data->HaveSpeedAndHeading) && (TimeToGoCheckBox->State == cbChecked))
             {

--- a/src/DisplayGUI.cpp
+++ b/src/DisplayGUI.cpp
@@ -327,17 +327,23 @@ void __fastcall TForm1::DrawObjects(void)
     double ScrX, ScrY;
     int ViewableAircraft = 0;
 
+    // --- drawing center crosshair ---
+    // below 5 lines are anti-aliasing options which can be turned off for performance
     glEnable(GL_LINE_SMOOTH);
     glEnable(GL_POINT_SMOOTH);
     glEnable(GL_BLEND);
     glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
     glHint(GL_LINE_SMOOTH_HINT, GL_NICEST);
+
+    // line settings
     glLineWidth(3.0);
     glPointSize(4.0);
-    glColor4f(1.0, 1.0, 1.0, 1.0);
+    glColor4f(1.0, 1.0, 1.0, 1.0); 
 
+    // XY position
     LatLon2XY(MapCenterLat, MapCenterLon, ScrX, ScrY);
 
+    // draw crosshair
     glBegin(GL_LINE_STRIP);
     glVertex2f(ScrX - 20.0, ScrY);
     glVertex2f(ScrX + 20.0, ScrY);
@@ -354,6 +360,7 @@ void __fastcall TForm1::DrawObjects(void)
 
     DWORD i, j, Count;
 
+    // --- drawing area of interest (polygon) ---
     if (AreaTemp)
     {
         glPointSize(3.0);
@@ -427,6 +434,7 @@ void __fastcall TForm1::DrawObjects(void)
         }
     }
 
+    // --- drawing aircrafts ---
     AircraftCountLabel->Caption = IntToStr((int)ght_size(HashTable));
     for (Data = (TADS_B_Aircraft *)ght_first(HashTable, &iterator, (const void **)&Key);
          Data; Data = (TADS_B_Aircraft *)ght_next(HashTable, &iterator, (const void **)&Key))
@@ -434,22 +442,25 @@ void __fastcall TForm1::DrawObjects(void)
         if (Data->HaveLatLon)
         {
             ViewableAircraft++;
-            glColor4f(1.0, 1.0, 1.0, 1.0);
+            glColor4f(1.0, 1.0, 1.0, 1.0);  // white color - is this necessary?
 
             LatLon2XY(Data->Latitude, Data->Longitude, ScrX, ScrY);
             // DrawPoint(ScrX,ScrY);
             if (Data->HaveSpeedAndHeading)
-                glColor4f(1.0, 0.0, 1.0, 1.0);
+                glColor4f(1.0, 0.0, 1.0, 1.0);  // with speed & heading - magenta color
             else
             {
                 Data->Heading = 0.0;
-                glColor4f(1.0, 0.0, 0.0, 1.0);
+                glColor4f(1.0, 0.0, 0.0, 1.0);  // no speed & heading - red
             }
 
-            DrawAirplaneImage(ScrX, ScrY, 1.5, Data->Heading, Data->SpriteImage);
+            DrawAirplaneImage(ScrX, ScrY, 1.5, Data->Heading, Data->SpriteImage);   // Draw airplane image
+
+            // ICAO code text besides the aircraft
             glRasterPos2i(ScrX + 30, ScrY - 10);
             ObjectDisplay->Draw2DText(Data->HexAddr);
 
+            // heading line
             if ((Data->HaveSpeedAndHeading) && (TimeToGoCheckBox->State == cbChecked))
             {
                 double lat, lon, az;
@@ -458,7 +469,7 @@ void __fastcall TForm1::DrawObjects(void)
                 {
                     double ScrX2, ScrY2;
                     LatLon2XY(lat, lon, ScrX2, ScrY2);
-                    glColor4f(1.0, 1.0, 0.0, 1.0);
+                    glColor4f(1.0, 1.0, 0.0, 1.0);  // yellow color for heading line
                     glBegin(GL_LINE_STRIP);
                     glVertex2f(ScrX, ScrY);
                     glVertex2f(ScrX2, ScrY2);
@@ -467,6 +478,8 @@ void __fastcall TForm1::DrawObjects(void)
             }
         }
     }
+
+    // --- side bar - contents for text box: Close Control which is for hooked airplane ----
     ViewableAircraftCountLabel->Caption = ViewableAircraft;
     if (TrackHook.Valid_CC)
     {
@@ -525,6 +538,8 @@ void __fastcall TForm1::DrawObjects(void)
             TrkLastUpdateTimeLabel->Caption = "N/A";
         }
     }
+
+    // --- side bar - contents for text box: CPA when two aircraft are hooked ----
     if (TrackHook.Valid_CPA)
     {
         bool CpaDataIsValid = false;
@@ -779,12 +794,14 @@ void __fastcall TForm1::HookTrack(int X, int Y, bool CPA_Hook)
     }
 }
 //---------------------------------------------------------------------------
+// convert lat/lon to x/y
 void __fastcall TForm1::LatLon2XY(double lat, double lon, double &x, double &y)
 {
     x = (Map_v[1].x - ((Map_w[1].x - (lon / 360.0)) / xf));
     y = Map_v[3].y - (Map_w[1].y / yf) + (asinh(tan(lat * M_PI / 180.0)) / (2 * M_PI * yf));
 }
 //---------------------------------------------------------------------------
+// convert x/y to lat/lon
 int __fastcall TForm1::XY2LatLon2(int x, int y, double &lat, double &lon)
 {
     double Lat, Lon, dlat, dlon, Range;

--- a/src/DisplayGUI.cpp
+++ b/src/DisplayGUI.cpp
@@ -457,7 +457,7 @@ void __fastcall TForm1::DrawObjects(void)
             DrawAirplaneImage(ScrX, ScrY, 1.5, Data->Heading, Data->SpriteImage);   // Draw airplane image
 
             // ICAO code text besides the aircraft
-            glRasterPos2i(ScrX + 30, ScrY - 10);
+            glRasterPos2i(ScrX + 60, ScrY - 10);
             ObjectDisplay->Draw2DText(Data->HexAddr);
 
             // heading line

--- a/src/DisplayGUI.dfm
+++ b/src/DisplayGUI.dfm
@@ -819,6 +819,11 @@ object Form1: TForm1
     Font2D_Type.Height = -27
     Font2D_Type.Name = 'Arial'
     Font2D_Type.Style = [fsBold]
+    Font2D_AdditionalType.Charset = ANSI_CHARSET
+    Font2D_AdditionalType.Color = clWindowText
+    Font2D_AdditionalType.Height = -12
+    Font2D_AdditionalType.Name = 'Arial'
+    Font2D_AdditionalType.Style = [fsBold]
     OnMouseDown = ObjectDisplayMouseDown
     OnMouseMove = ObjectDisplayMouseMove
     OnMouseUp = ObjectDisplayMouseUp

--- a/src/DisplayGUI.dfm
+++ b/src/DisplayGUI.dfm
@@ -209,7 +209,7 @@ object Form1: TForm1
         MaxValue = 1000
         MinValue = 5
         TabOrder = 2
-        Value = 90
+        Value = 30
       end
       object PurgeButton: TButton
         Left = 186

--- a/src/DisplayGUI.dfm
+++ b/src/DisplayGUI.dfm
@@ -821,7 +821,7 @@ object Form1: TForm1
     Font2D_Type.Style = [fsBold]
     Font2D_AdditionalType.Charset = ANSI_CHARSET
     Font2D_AdditionalType.Color = clWindowText
-    Font2D_AdditionalType.Height = -12
+    Font2D_AdditionalType.Height = -15
     Font2D_AdditionalType.Name = 'Arial'
     Font2D_AdditionalType.Style = [fsBold]
     OnMouseDown = ObjectDisplayMouseDown

--- a/src/DisplayGUI.h
+++ b/src/DisplayGUI.h
@@ -44,6 +44,7 @@ typedef struct
 } TPolyLine;
 
 #define MAX_AREA_POINTS 500
+
 typedef struct
 {
     AnsiString Name;
@@ -53,7 +54,8 @@ typedef struct
     pfVec3 PointsAdj[MAX_AREA_POINTS];
     TTriangles *Triangles;
     bool Selected;
-} TArea;
+} TArea;    // Target Area - area of interest
+
 //---------------------------------------------------------------------------
 class TTCPClientRawHandleThread : public TThread
 {
@@ -234,9 +236,9 @@ private: // User declarations
 public:  // User declarations
     __fastcall TForm1(TComponent *Owner);
     __fastcall ~TForm1();
-    void __fastcall LatLon2XY(double lat, double lon, double &x, double &y);
-    int __fastcall XY2LatLon2(int x, int y, double &lat, double &lon);
-    void __fastcall HookTrack(int X, int Y, bool CPA_Hook);
+    void __fastcall LatLon2XY(double lat, double lon, double &x, double &y);    // convert lat/lon to x/y
+    int __fastcall XY2LatLon2(int x, int y, double &lat, double &lon);          // convert x/y to lat/lon
+    void __fastcall HookTrack(int X, int Y, bool CPA_Hoo);
     void __fastcall DrawObjects(void);
     void __fastcall DeleteAllAreas(void);
     void __fastcall Purge(void);
@@ -259,7 +261,7 @@ public:  // User declarations
     int g_MouseLeftDownY;
     int g_MouseDownMask;
     TList *Areas;
-    TArea *AreaTemp;
+    TArea *AreaTemp;    // target area - area of interest
     ght_hash_table_t *HashTable;
     TTCPClientRawHandleThread *TCPClientRawHandleThread;
     TTCPClientSBSHandleThread *TCPClientSBSHandleThread;

--- a/src/TimeFunctions.cpp
+++ b/src/TimeFunctions.cpp
@@ -41,3 +41,18 @@ char *TimeToChar(__int64 hmsm)
     return timdsp;
 }
 //---------------------------------------------------------------------------
+void TimeDifferenceInSecToChar(__int64 timestamp, char *buffer, int bufferSize)
+{
+    __int64 diff = GetCurrentTimeInMsec() - timestamp;
+
+    buffer[0] = '\0'; // Ensure null-termination
+    if (diff < 0)
+    {
+        return;
+    }
+
+    int seconds = static_cast<int>(diff / 1000);
+
+    snprintf(buffer, bufferSize, "%d", seconds);
+}
+//---------------------------------------------------------------------------

--- a/src/TimeFunctions.h
+++ b/src/TimeFunctions.h
@@ -5,5 +5,6 @@
 
 __int64 GetCurrentTimeInMsec(void);
 char *TimeToChar(__int64 hmsm);
+void TimeDifferenceInSecToChar(__int64 timestamp, char *buffer, int bufferSize);
 //---------------------------------------------------------------------------
 #endif


### PR DESCRIPTION
- [d3300c2](https://github.com/jacob-ku/CMU-Architecture-T1/commit/d3300c215dc62234365be394ba5b00eadcdac809): 주석 추가 - DisplayGUI 내 DrawObjects, lat/long <-> XY 변환, Target Area (Area of Interest) 구조체 
- [18d574f](https://github.com/jacob-ku/CMU-Architecture-T1/commit/18d574f0c114dc7af24eaba36f6208f88184984b): purge stale 기본값 90->30 변경
- [3089be7](https://github.com/jacob-ku/CMU-Architecture-T1/commit/3089be78355562a65179828d688a5189828990f9): aircraft image와 ICAO 텍스트 모든 방향에서 겹치지 않도록 간격 조정 (x distance: 30 -> 60)
- [e34884d](https://github.com/jacob-ku/CMU-Architecture-T1/commit/e34884d217a2f5fc99084043217d3278488e00a1): ICAO(타이틀) 이외 추가 정보 map 표시를 위한 OpenGL 2D 텍스트 개체 추가 (OpenGL)
  - *This requires "Build and Install" of **OpenGLPanel_DP** project on "src\Components\OpenGLv0.5BDS2006\Component" path*
    - Build: 32 & 64-bits  Target with Release configuration
    - Install: 32 bits + Release configuration
- [89b3723](https://github.com/jacob-ku/CMU-Architecture-T1/commit/89b3723b63d0b5f4fd262123be8da2e831bebf37): add track age to be displayed below the ICAO code
  - ![image](https://github.com/user-attachments/assets/8139f7c4-607f-4af4-a77b-4de1f6b9b8a7)
